### PR TITLE
Add a worker process for the consumer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ click==6.7
 docutils==0.13.1          # via botocore
 futures==3.0.5            # via s3transfer
 jmespath==0.9.1           # via boto3, botocore
-kinesis-python==0.0.5
+kinesis-python==0.0.6
 python-dateutil==2.6.0    # via botocore
 s3transfer==0.1.10        # via boto3
 six==1.10.0               # via python-dateutil

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('VERSION') as version_fd:
     version = version_fd.read().strip()
 
 install_requires = [
-    'kinesis-python>=0.0.5,<1.0',
+    'kinesis-python>=0.0.6,<1.0',
     'click>=6.6,<7.0',
 ]
 

--- a/src/motion/worker.py
+++ b/src/motion/worker.py
@@ -3,58 +3,89 @@ import logging
 import Queue
 import multiprocessing
 import signal
+import sys
 
 log = logging.getLogger(__name__)
 
 
-class MotionWorker(object):
-    def __init__(self, queue, responders):
-        self.queue = queue
-        self.responders = responders
+class MotionProcess(object):
+    """Base class for forked workers via multiprocessing.Process"""
+    def __init__(self):
         self.process = None
         self.alive = True
 
         atexit.register(self.shutdown)
-        self.process = multiprocessing.Process(target=self.run)
+        self.process = multiprocessing.Process(target=self._run)
         self.process.start()
 
     def shutdown(self):
         if self.process:
-            log.info("Worker shutting down")
+            log.info("%s shutting down", self.__class__.__name__)
             self.process.terminate()
             self.process.join()
             self.process = None
 
-    def signal_handler(self, signum, frame):
+    def _signal_handler(self, signum, frame):
         log.info("Caught signal %s", signum)
         self.alive = False
 
-    def run(self):
-        signal.signal(signal.SIGTERM, self.signal_handler)
+    def _run(self):
+        signal.signal(signal.SIGTERM, self._signal_handler)
 
-        log.info("Worker starting")
+        log.info("%s starting", self.__class__.__name__)
 
         while self.alive:
             try:
-                event_name, payload = self.queue.get(block=True, timeout=0.1)
-            except Queue.Empty:
-                continue
-            except (SystemExit, KeyboardInterrupt):
-                log.error("Exiting via interrupt")
+                self.work()
+            except Exception:
+                log.exception("Unhandled exception in base MotionProcess")
                 self.alive = False
-                break
-            except Exception:
-                log.exception("Failed to get event & payload from queue")
-                continue
+                return sys.exit(1)
 
-            responder = self.responders[event_name]
+    def work(self):
+        raise NotImplementedError
 
-            try:
-                result = responder(payload)
-            except Exception:
-                log.exception("Unhandled exception while processing payload for event %s", event_name)
-                continue
 
-            log.debug("Processed event %s with payload %s, got result %s", event_name, payload, result)
+class MotionConsumer(MotionProcess):
+    def __init__(self, app):
+        self.app = app
+        super(MotionConsumer, self).__init__()
 
-            # XXX TODO: add result storage?
+    def work(self):
+        self.app.consume()
+
+        # we should never reach this
+        log.error("Failed to consume from Kinesis!")
+        sys.exit(2)
+
+
+class MotionWorker(MotionProcess):
+    def __init__(self, queue, responders):
+        self.queue = queue
+        self.responders = responders
+        super(MotionWorker, self).__init__()
+
+    def work(self):
+        try:
+            event_name, payload = self.queue.get(block=True, timeout=0.1)
+        except Queue.Empty:
+            return
+        except (SystemExit, KeyboardInterrupt):
+            log.error("Exiting via interrupt")
+            self.alive = False
+            return
+        except Exception:
+            log.exception("Failed to get event & payload from queue")
+            return
+
+        responder = self.responders[event_name]
+
+        try:
+            result = responder(payload)
+        except Exception:
+            log.exception("Unhandled exception while processing payload for event %s", event_name)
+            return
+
+        log.debug("Processed event %s with payload %s, got result %s", event_name, payload, result)
+
+        # XXX TODO: add result storage?


### PR DESCRIPTION
Previously when you ran the workers they couldn't respond to anything since nothing started the consumer process by calling `app.consume()`.... *facepalm*

This changes the `check_workers` function so that it checks & starts processes for the consumer as well as all of the actual task workers.