### PR TITLE
Upgrade kinesis, use offspring, fix some bugs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ click==6.7
 docutils==0.13.1          # via botocore
 futures==3.0.5            # via s3transfer
 jmespath==0.9.1           # via boto3, botocore
-kinesis-python==0.0.6
+kinesis-python==0.1.1
+offspring==0.0.3
 python-dateutil==2.6.0    # via botocore
 s3transfer==0.1.10        # via boto3
 six==1.10.0               # via python-dateutil

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,9 @@ with open('VERSION') as version_fd:
     version = version_fd.read().strip()
 
 install_requires = [
-    'kinesis-python>=0.0.6,<1.0',
     'click>=6.6,<7.0',
+    'kinesis-python>=0.1.1,<0.9',
+    'offspring>=0.0.3,<0.9',
 ]
 
 setup(

--- a/src/motion/motion.py
+++ b/src/motion/motion.py
@@ -68,7 +68,7 @@ class Motion(object):
         for message in self.consumer:
             log.debug("Consumed message: %s", message)
             try:
-                event_name, payload = self.marshal.to_native(message)
+                event_name, payload = self.marshal.to_native(message['Data'])
             except MarshalFailure:
                 log.warn("Failed to marshal message to native objects, skipping")
                 continue
@@ -80,7 +80,7 @@ class Motion(object):
                 log.warn("No responder for event %s registered, skipping", event_name)
                 continue
 
-            self.responder_queue.put_nowait((event_name, payload))
+            self.responder_queue.put((event_name, payload))
 
     def dispatch(self, event_name, payload):
         self.producer.put(self.marshal.to_bytes(event_name, payload))

--- a/src/motion/motion.py
+++ b/src/motion/motion.py
@@ -21,7 +21,7 @@ class Motion(object):
         Motion._INSTANCES.append(inst)
         return inst
 
-    def __init__(self, stream_name, marshal=None, concurrency=None, boto3_session=None):
+    def __init__(self, stream_name, marshal=None, concurrency=None, boto3_session=None, kinesis_state=None):
         """Create a new motion application
 
         :param stream_name: the name of the kinesis stream to use
@@ -36,7 +36,7 @@ class Motion(object):
 
         self.stream_name = stream_name
         self.producer = KinesisProducer(stream_name, boto3_session=boto3_session)
-        self.consumer = KinesisConsumer(stream_name, boto3_session=boto3_session)
+        self.consumer = KinesisConsumer(stream_name, boto3_session=boto3_session, state=kinesis_state)
         self.marshal = marshal or JSONMarshal()
         self.concurrency = concurrency or 1
         self.responder_queue = multiprocessing.Queue()

--- a/src/motion/worker.py
+++ b/src/motion/worker.py
@@ -1,9 +1,10 @@
-import atexit
 import logging
-import Queue
-import multiprocessing
-import signal
 import sys
+
+try:
+    from queue import Empty
+except ImportError:
+    from Queue import Empty
 
 from offspring import Subprocess, SubprocessLoop
 
@@ -32,7 +33,7 @@ class MotionWorker(SubprocessLoop):
     def loop(self):
         try:
             event_name, payload = self.queue.get(block=True, timeout=0.25)
-        except Queue.Empty:
+        except Empty:
             return
         except Exception:
             log.exception("Failed to get event & payload from queue")


### PR DESCRIPTION
* Upgrade kinesis-python to get the new state & locking!

* Move to offspring for subprocess management

* Ensure we marshal the `Data` element of our message -- not the whole thing 🤦‍♂️ 

* Use `.put` instead of `.put_nowait` for our responder queue.  Now that we checkpoint when the message is received from the consumer we don't want to pull messages from the consumer until we have workers available to process them.