### PR TITLE
Make AWS clients lazy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ click==6.7
 docutils==0.13.1          # via botocore
 futures==3.0.5            # via s3transfer
 jmespath==0.9.1           # via boto3, botocore
-kinesis-python==0.1.1
+kinesis-python==0.1.2
 offspring==0.0.3
 python-dateutil==2.6.0    # via botocore
 s3transfer==0.1.10        # via boto3

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('VERSION') as version_fd:
 
 install_requires = [
     'click>=6.6,<7.0',
-    'kinesis-python>=0.1.1,<0.9',
+    'kinesis-python>=0.1.2,<0.9',
     'offspring>=0.0.3,<0.9',
 ]
 


### PR DESCRIPTION
Motion app objects can be created without necessarily being used.  In some cases we may only consume and not publish, or vice-versa.  For these use cases paying to start the kinesis consumer and producer processes is not worth it.  In fact, it causes problems because the async producer doesn't auto terminate on exit, which can lead to hung processes.

This moves the producer, consumer & dynamo objects to only get created when they are accessed.