### PR TITLE
Allow multiple responders to subscribe to an event

### DIFF
--- a/src/motion/motion.py
+++ b/src/motion/motion.py
@@ -106,7 +106,7 @@ class Motion(object):
                 continue
 
             for index in xrange(len(self.responders[event_name])):
-                self.responder_queue.put((event_name, payload, index))
+                self.responder_queue.put((event_name, index, payload))
 
     def dispatch(self, event_name, payload):
         self.producer.put(self.marshal.to_bytes(event_name, payload))

--- a/src/motion/worker.py
+++ b/src/motion/worker.py
@@ -32,14 +32,14 @@ class MotionWorker(SubprocessLoop):
 
     def loop(self):
         try:
-            event_name, payload = self.queue.get(block=True, timeout=0.25)
+            event_name, payload, responder_index = self.queue.get(block=True, timeout=0.25)
         except Empty:
             return
         except Exception:
             log.exception("Failed to get event & payload from queue")
             return
 
-        responder = self.responders[event_name]
+        responder = self.responders[event_name][responder_index]
 
         try:
             result = responder(payload)

--- a/src/motion/worker.py
+++ b/src/motion/worker.py
@@ -32,7 +32,7 @@ class MotionWorker(SubprocessLoop):
 
     def loop(self):
         try:
-            event_name, payload, responder_index = self.queue.get(block=True, timeout=0.25)
+            event_name, responder_index, payload = self.queue.get(block=True, timeout=0.25)
         except Empty:
             return
         except Exception:


### PR DESCRIPTION
This modifies the library so that multiple responders can be registered for the same event, and the task queue will enqueue _N_ copies of the payload, each one addressed to a specific listener