### PR TITLE
Use fnmatch to match responder patterns

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ click==6.7
 docutils==0.13.1          # via botocore
 futures==3.0.5            # via s3transfer
 jmespath==0.9.1           # via boto3, botocore
-kinesis-python==0.1.2
-offspring==0.0.3
+kinesis-python==0.1.6
+offspring==0.1.1
 python-dateutil==2.6.0    # via botocore
 s3transfer==0.1.10        # via boto3
-six==1.10.0               # via python-dateutil
+six==1.11.0               # via kinesis-python, python-dateutil

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ with open('VERSION') as version_fd:
 
 install_requires = [
     'click>=6.6,<7.0',
-    'kinesis-python>=0.1.2,<0.9',
-    'offspring>=0.0.3,<0.9',
+    'kinesis-python>=0.1.6,<1.0',
+    'offspring>=0.1.1,<1.0',
 ]
 
 setup(

--- a/src/motion/motion.py
+++ b/src/motion/motion.py
@@ -1,4 +1,5 @@
 import collections
+import fnmatch
 import logging
 import multiprocessing
 
@@ -18,6 +19,7 @@ def cached_property(func):
     attr = '_{0}'.format(func.__name__)
 
     @property
+    @functools.wraps(func)
     def _cached_property(self):
         try:
             return getattr(self, attr)
@@ -96,12 +98,11 @@ class Motion(object):
                 log.exception("Unhandled exception while marshaling message to native: %s", message)
                 continue
 
-            if event_name not in self.responders:
-                log.warn("No responder for event %s registered, skipping", event_name)
-                continue
-
-            for index in xrange(len(self.responders[event_name])):
-                self.responder_queue.put((event_name, index, payload))
+            for responder_pattern in self.responders:
+                if fnmatch.fnmatch(event_name, responder_pattern):
+                    log.debug("Matched responder pattern %s against event name %s", responder_pattern, event_name)
+                    for index in xrange(len(self.responders[responder_pattern])):
+                        self.responder_queue.put((event_name, index, payload))
 
     def dispatch(self, event_name, payload):
         self.producer.put(self.marshal.to_bytes(event_name, payload))

--- a/src/motion/motion.py
+++ b/src/motion/motion.py
@@ -1,5 +1,6 @@
 import collections
 import fnmatch
+import functools
 import logging
 import multiprocessing
 


### PR DESCRIPTION
I have a need to match all events with a motion responder.

This PR moves to using the `fnmatch` for selecting responder.

This means that you could now do `@app.respond_to('*')` to respond to all events, or `@app.respond_to('deploy.*')` to respond to all deploy events.