### PR TITLE
Allow responders to receive the event name

### DIFF
--- a/src/motion/motion.py
+++ b/src/motion/motion.py
@@ -83,7 +83,7 @@ class Motion(object):
 
     def respond_to(self, pattern, pass_event_name=False):
         def decorator(func):
-            self.responders[event_name].append(func)
+            self.responders[pattern].append(func)
             func._motion_pass_event_name = pass_event_name
             return func
         return decorator

--- a/src/motion/motion.py
+++ b/src/motion/motion.py
@@ -81,9 +81,10 @@ class Motion(object):
     def consumer(self):
         return KinesisConsumer(self.stream_name, boto3_session=self.boto3_session, state=self.consumer_state)
 
-    def respond_to(self, event_name):
+    def respond_to(self, pattern, pass_event_name=False):
         def decorator(func):
             self.responders[event_name].append(func)
+            func._motion_pass_event_name = pass_event_name
             return func
         return decorator
 
@@ -103,7 +104,7 @@ class Motion(object):
                 if fnmatch.fnmatch(event_name, responder_pattern):
                     log.debug("Matched responder pattern %s against event name %s", responder_pattern, event_name)
                     for index in xrange(len(self.responders[responder_pattern])):
-                        self.responder_queue.put((event_name, index, payload))
+                        self.responder_queue.put((responder_pattern, index, event_name, payload))
 
     def dispatch(self, event_name, payload):
         self.producer.put(self.marshal.to_bytes(event_name, payload))


### PR DESCRIPTION
#6 was a little hasty (we should really write some tests...) and has two major problems.

The main problem with the implementation is that we were putting the full event name on the worker/responder queue, when we should've been putting the pattern.

The problem with the idea is that if we do:

```python
@app.respond_to('*')
def all_the_things(payload):
    # We have no way of getting the event name... :(
```

This PR fixes those.

Now we pass both the pattern and the event name over the queue, and you can do:

```python
@app.respond_to('*', pass_event_name=True)
def all_the_things(payload, event_name):
    # ...
```
