### PR TITLE
Allow the json cls argument to be easily overriden

### DIFF
--- a/src/motion/marshal.py
+++ b/src/motion/marshal.py
@@ -13,18 +13,21 @@ class MarshalFailure(Exception):
 
 class JSONMarshal(object):
     """Simple JSON Marshal"""
+    JSON_DUMP_CLS = None
+    JSON_LOAD_CLS = None
+    
     def to_bytes(self, event_name, payload):
         try:
             return json.dumps({
                 'event_name': event_name,
                 'payload': payload
-            })
+            }, cls=self.JSON_DUMP_CLS)
         except ValueError:
             raise MarshalFailure("Could not convert payload to JSON", payload)
 
     def to_native(self, payload):
         try:
-            native = json.loads(payload)
+            native = json.loads(payload, cls=self.JSON_LOAD_CLS)
         except ValueError:
             raise MarshalFailure("Could not load valid JSON from payload", payload)
         return native['event_name'], native['payload']


### PR DESCRIPTION
This will allow for easy swapping out of the default encoder / decoder class without needing to do any actual work in the subclass other than setting the new attrs.

```python
class MyJSONMarshal(JSONMarshal):
    JSONEncoder = MyEncoder
    JSONDecoder = MyDecoder
```